### PR TITLE
Only set `groceries` in state once when removing from purchased list

### DIFF
--- a/react_groceries/src/components/Main/GroceryList/GroceryItem.jsx
+++ b/react_groceries/src/components/Main/GroceryList/GroceryItem.jsx
@@ -8,7 +8,7 @@ class GroceryItem extends Component {
    handleIsPurchased = (event)=>{
     event.preventDefault();
     this.props.handleIsPurchased(!this.state.isPurchased,this.props.index,this.state.quantity)
-    this.props.handleOnChangeQuantity(this.state.quantity,this.props.index)
+    this.props.handleOnChangeQuantity?.(this.state.quantity,this.props.index)
    }
    handleOnChangeQuantity = (event)=>{
         this.setState({ [event.target.id]: event.target.value })

--- a/react_groceries/src/components/Main/Main.jsx
+++ b/react_groceries/src/components/Main/Main.jsx
@@ -104,7 +104,7 @@ class Main extends Component {
                 className="Purchased "
                 buttonName="Remove"
                 title={"Purchased Item"}
-                handleOnChangeQuantity={this.handleOnChangeQuantity}
+                // handleOnChangeQuantity={this.handleOnChangeQuantity}
                 handleIsPurchased={this.handleRemove}
                 grocery={groceryItem[0]}
                 index={index}


### PR DESCRIPTION
You were right about how `this.setState` works in your code. I'm sorry for arguing otherwise in class.

Here's my attempt at fixing the current error. What I've done is:

1. Don't pass `handleOnChangeQuantity` to the Remove button. I think that might be setting the wrong state
2. Use the [optional chaining operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining#optional_chaining_with_function_calls) for shorter code. Since I'm no longer always passing `handleOnChangeQuantity`, the optional chaining operator makes sure the code doesn't throw an error when trying to call a method that's unavailable.

I haven't tested the code enough to be confident in this fix, but I did think it was worth sharing and I hope it helps.